### PR TITLE
Update engine versions and NodeJS binary path

### DIFF
--- a/rocketchatctl
+++ b/rocketchatctl
@@ -476,9 +476,6 @@ create_rocketchat_systemd_file(){
     if [[ $webserver != "none" ]] && $bind_loopback; then
         BIND_IP="127.0.0.1"
     fi
-    if [[ $distro == "centos" ]]; then
-        node_path="/usr/local/bin/node"
-    fi
     cat << EOF | tee -a /lib/systemd/system/rocketchat.service
 [Unit]
 Description=The Rocket.Chat server
@@ -1193,7 +1190,7 @@ main() {
     local configure_webserver=0
     local root_url_arg=0
     local sufix=$(date +%s)
-    local node_path="/usr/bin/node"
+    local node_path="/usr/local/bin/node"
     local backup_dir="/tmp"
     local update_node=0
     

--- a/rocketchatctl
+++ b/rocketchatctl
@@ -1149,8 +1149,8 @@ do_backup(){
 main() {
 
     local VERSION="latest"
-    local -r NODE_VERSION="v12.14.0"
-    local -r NPM_VERSION="6.13.4"
+    local -r NODE_VERSION="v12.18.4"
+    local -r NPM_VERSION="6.14.8"
     local MONGO_VERSION=""
     local -r MONGO_URL="mongodb://localhost:27017/rocketchat?replicaSet=rs01"
     local -r MONGO_OPLOG_URL="mongodb://localhost:27017/local?replicaSet=rs01"


### PR DESCRIPTION
- Use correct engine versions of NodeJS and NPM for latest (3.9.0) Rocket.Chat release (Resolve #33)
- Always use node binary in `/usr/local/bin/` since that seems to be [the default `$N_PREFIX`](https://github.com/tj/n/blob/master/bin/n#L48) across all distros

Anyone who already updated to Rocket.Chat 3.9.0 in the meantime, please make sure that NodeJS version 12.18.4 is currently the active version (`n 12.18.4`).