### PR TITLE
Fixed getting the PORT of the current rocketchat installation in get_…

### DIFF
--- a/rocketchatctl
+++ b/rocketchatctl
@@ -762,7 +762,7 @@ get_rocketchat_latest_version(){
 
 get_rocketchat_current_version(){
     if systemctl status rocketchat > /dev/null 2>&1; then
-        PORT=$(cat /lib/systemd/system/rocketchat.service |grep PORT |awk -F= '{print $3}')
+        PORT=$(cat /lib/systemd/system/rocketchat.service |grep PORT | sed 's/.*PORT=\([^][,[:space:]]*\).*/\1/')
         current_rocketchat_version=$(curl http://localhost:$PORT/api/info 2>/dev/null |cut -d\" -f4)
     else
         print_rocketchat_not_running_error_and_exit


### PR DESCRIPTION
…rocketchat_current_version() fixing issue-#37

In the function get_rocketchat_current_version() the PORT of the current rocketchat installation was not obtained correctly as the previous code depends on the location of the PORT definition in the corresponding line in /lib/systemd/system/rocketchat.service. As the location of the PORT in that string might vary the code must be able to obtain the PORT value regardless of the location. Fixing issue-#37