### PR TITLE
Fix update to Rocket.Chat 4.0

### DIFF
--- a/rocketchatctl
+++ b/rocketchatctl
@@ -777,7 +777,7 @@ rocketchat_health_check(){
     local count=0
     while ! ([ $rocket_healthy -eq  1 ] || [ $count -eq 150 ]); do
         get_rocketchat_current_version
-        [[ $current_rocketchat_version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && rocket_healthy=1
+        [[ $current_rocketchat_version =~ ^[0-9]+\.[0-9]+$ ]] && rocket_healthy=1
         sleep 2
         ((count++))
         echo "Waiting up to 5 minutes for RocketChat server to be active ... $(($count * 2))"

--- a/rocketchatctl
+++ b/rocketchatctl
@@ -777,7 +777,7 @@ rocketchat_health_check(){
     local count=0
     while ! ([ $rocket_healthy -eq  1 ] || [ $count -eq 150 ]); do
         get_rocketchat_current_version
-        [[ $current_rocketchat_version =~ ^[0-9]+\.[0-9]+$ ]] && rocket_healthy=1
+        [[ $current_rocketchat_version =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]] && rocket_healthy=1
         sleep 2
         ((count++))
         echo "Waiting up to 5 minutes for RocketChat server to be active ... $(($count * 2))"


### PR DESCRIPTION
Compare just major and minor version since starting on Rocket.Chat 4.0 `/api/info` doesn't return the patch version for unauthenticated requests as per https://github.com/RocketChat/Rocket.Chat/pull/16050

Closes https://github.com/RocketChat/install.sh/issues/48
Closes https://github.com/RocketChat/Rocket.Chat/issues/23358
Closes https://github.com/RocketChat/Rocket.Chat/issues/23356