### PR TITLE
install.sh fix ROCKETCHATCTL_DOWNLOAD_URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly ROCKETCHATCTL_DOWNLOAD_URL="https://install.rocket.chat/rocketchatctl"
+readonly ROCKETCHATCTL_DOWNLOAD_URL="https://raw.githubusercontent.com/RocketChat/install.sh/master/rocketchatctl"
 readonly ROCKETCHATCTL_DIRECTORY="/usr/local/bin"
 
 if [ ${EUID} -ne 0 ]; then

--- a/rocketchatctl
+++ b/rocketchatctl
@@ -1202,7 +1202,6 @@ main() {
 
   local -r ROCKETCHATCTL_DOWNLOAD_URL="https://raw.githubusercontent.com/RocketChat/install.sh/master/rocketchatctl"
   local -r ROCKETCHATCTL_DIRECTORY="/usr/local/bin"
-  local -r ROCKETCHATCTL_TEMP_DIRECTORY="/tmp"
 
   local -r TRAEFIK_DOWNLOAD_URL="https://github.com/containous/traefik/releases/download/v1.7.20/traefik"
   local -r CADDY_DOWNLOAD_URL="https://github.com/mholt/caddy/releases/download/v1.0.0/caddy_v1.0.0_linux_amd64.tar.gz"


### PR DESCRIPTION
And please, remove the file at `https://install.rocket.chat/rocketchatctl` - it's obsolete.